### PR TITLE
Apply more robust connection ID generation strategy to avoid conflicts

### DIFF
--- a/opennsa/backends/kytos.py
+++ b/opennsa/backends/kytos.py
@@ -9,6 +9,7 @@
 
 """
 
+import string
 import random
 import json
 import traceback
@@ -419,7 +420,7 @@ class KytosConnectionManager:
         return self.port_map[port] + "#" + str(vlan)
 
     def createConnectionId(self, source_target, dest_target):
-        return "Kytos-" + str(random.randint(100000, 999999))
+        return "K-" + ''.join( [ random.choice(string.hexdigits[:16]) for _ in range(8) ] )
 
     def canSwapLabel(self, label_type):
         return True


### PR DESCRIPTION
Fix #6 

### Description

This PR adds an enhancement to Kytos backend implementation to generate Connection IDs more randomly using string hex combinations (similar to Brocade, Force10 and other backends).